### PR TITLE
Add replacement for AddTestConfiguration method

### DIFF
--- a/Solutions/Corvus.Configuration.Specs/Steps/AddTestConfigurationSteps.cs
+++ b/Solutions/Corvus.Configuration.Specs/Steps/AddTestConfigurationSteps.cs
@@ -33,7 +33,7 @@ namespace Corvus.Configuration.Specs.Steps
 
             string fileName = this.context.Get<string>("filename");
 
-            configBuilder.AddTestConfiguration(fileName);
+            configBuilder.AddConfigurationForTest(fileName);
 
             IConfigurationRoot config = configBuilder.Build();
 

--- a/Solutions/Corvus.Configuration.TestEnvironment/Corvus/Configuration/ConfigurationExtensions.cs
+++ b/Solutions/Corvus.Configuration.TestEnvironment/Corvus/Configuration/ConfigurationExtensions.cs
@@ -39,7 +39,7 @@ namespace Corvus.Configuration
         /// }
         /// .
         /// </remarks>
-        [Obsolete("Use AddConfigurationForTest() instead.")]
+        [Obsolete("Use AddConfigurationForTest() instead. See https://github.com/corvus-dotnet/Corvus.Configuration/pull/71 for more information.")]
         public static void AddTestConfiguration(this IConfigurationBuilder builder, string filePath, IDictionary<string, string> fallbackSettings = null)
         {
             if (string.IsNullOrEmpty(filePath))

--- a/Solutions/Corvus.Configuration.TestEnvironment/Corvus/Configuration/ConfigurationExtensions.cs
+++ b/Solutions/Corvus.Configuration.TestEnvironment/Corvus/Configuration/ConfigurationExtensions.cs
@@ -39,6 +39,7 @@ namespace Corvus.Configuration
         /// }
         /// .
         /// </remarks>
+        [Obsolete("Use AddConfigurationForTest() instead.")]
         public static void AddTestConfiguration(this IConfigurationBuilder builder, string filePath, IDictionary<string, string> fallbackSettings = null)
         {
             if (string.IsNullOrEmpty(filePath))
@@ -55,6 +56,54 @@ namespace Corvus.Configuration
             var codebase = new Uri(typeof(ConfigurationExtensions).Assembly.CodeBase);
             builder.SetBasePath(Path.GetDirectoryName(codebase.LocalPath));
             builder.AddJsonFile(filePath, optional: true, reloadOnChange: true);
+
+            // On the build server, we expect configuration comes through environment variables.
+            builder.AddEnvironmentVariables();
+        }
+
+        /// <summary>
+        /// Adds standard configuration tools for the test environment.
+        /// </summary>
+        /// <param name="builder">The configuration builder to configure.</param>
+        /// <param name="filePath">
+        /// The file path of the local json configuration file to use, relative to the current executing assembly. If there
+        /// is no local json configuration file, this can be set to null.
+        /// </param>
+        /// <param name="fallbackSettings">
+        /// Any fallback settings to apply if not overridden elsewhere. If there are no fallback settings, this can be
+        /// set to null.
+        /// </param>
+        /// <remarks>
+        /// Local json files should contain configuration in either of the following json structures:
+        /// 1. Nested properties
+        /// {
+        ///   "Test": {
+        ///    "Property":  "Value"
+        ///   }
+        /// }
+        /// 2. Flattened, colon separated properties
+        /// {
+        ///  "Test:Property": "Value"
+        /// }
+        /// .
+        /// </remarks>
+        public static void AddConfigurationForTest(
+            this IConfigurationBuilder builder,
+            string filePath = null,
+            IDictionary<string, string> fallbackSettings = null)
+        {
+            if (fallbackSettings != null)
+            {
+                builder.AddInMemoryCollection(fallbackSettings);
+            }
+
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                // Add a JSON file if present for local dev
+                var codebase = new Uri(typeof(ConfigurationExtensions).Assembly.CodeBase);
+                builder.SetBasePath(Path.GetDirectoryName(codebase.LocalPath));
+                builder.AddJsonFile(filePath, optional: true, reloadOnChange: true);
+            }
 
             // On the build server, we expect configuration comes through environment variables.
             builder.AddEnvironmentVariables();


### PR DESCRIPTION
Resolves #70 

Adds a new method to implement the desired behaviour - supplying a null value for the settings file name results in no settings file being added. Marked the old method obsolete to make it obvious what should be used instead.

It was necessary to add a new method rather than updating the existing one because that option would have resulted in a method with the same signature as in 0.3.0 but very different behaviour. In that version, not supplying a filename would default the name to local.settings.json, but in this new version it simply wouldn't load the file. This could lead to hard-to-find test failures.
