### PR TITLE
Update to SpecFlow 3.1.89

### DIFF
--- a/Solutions/Corvus.Configuration.Specs/Corvus.Configuration.Specs.csproj
+++ b/Solutions/Corvus.Configuration.Specs/Corvus.Configuration.Specs.csproj
@@ -24,9 +24,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow" Version="3.1.86" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.1.86" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.86" />
+    <PackageReference Include="SpecFlow" Version="3.1.89" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.1.89" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.89" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.8.0">

--- a/Solutions/Corvus.Configuration.Specs/Corvus.Configuration.Specs.csproj
+++ b/Solutions/Corvus.Configuration.Specs/Corvus.Configuration.Specs.csproj
@@ -24,9 +24,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow" Version="3.1.80" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.1.80" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.80" />
+    <PackageReference Include="SpecFlow" Version="3.1.86" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.1.86" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.86" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.8.0">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ resources:
       type: github
       name: endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub
       endpoint: corvus-dotnet-github
-      ref:  feature/22-revert-to-older-31-sdk 
 
 jobs:
 - template: templates/build.and.release.yml@recommended_practices

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ resources:
       type: github
       name: endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub
       endpoint: corvus-dotnet-github
+      ref:  feature/22-revert-to-older-31-sdk 
 
 jobs:
 - template: templates/build.and.release.yml@recommended_practices


### PR DESCRIPTION
Resolves #80 

The build failures are caused by an incompatibility between SpecFlow and the .NET Core SDK 3.1.200, so the most important change regarding this issue is https://github.com/endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub/pull/23

However, during testing when trying to get to the bottom of this build failure, I also encountered a symptom that can be caused by a bug that was fixed in SpecFlow 3.1.89, so it seems like a good idea to update anyway.