### PR TITLE
Use floating versions for System/Microsoft dependencies

### DIFF
--- a/Solutions/Corvus.Configuration.Specs/Corvus.Configuration.Specs.csproj
+++ b/Solutions/Corvus.Configuration.Specs/Corvus.Configuration.Specs.csproj
@@ -20,8 +20,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.16" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.*,)" />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Corvus.Configuration.TestEnvironment\Corvus.Configuration.TestEnvironment.csproj" />

--- a/Solutions/Corvus.Configuration.TestEnvironment/Corvus.Configuration.TestEnvironment.csproj
+++ b/Solutions/Corvus.Configuration.TestEnvironment/Corvus.Configuration.TestEnvironment.csproj
@@ -19,10 +19,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.16" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.*,)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.*,)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[3.1.*,)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.*,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.Configuration/Corvus.Configuration.csproj
+++ b/Solutions/Corvus.Configuration/Corvus.Configuration.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.*,)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Also update to Corvus.Testing 1.4.4 (which also uses floating dependencies)